### PR TITLE
[codex] Add realtime composer transcription

### DIFF
--- a/apps/meseeks/convex/magicRock.tsx
+++ b/apps/meseeks/convex/magicRock.tsx
@@ -1,20 +1,14 @@
-// TODO: move back to AI SDK when possible
-// We moved away from AI SDK's transcribe() after finding out it was forcing
-// file type to audio/wav, breaking transcription. We spent too many hours on that already.
-
 import { z } from 'zod/v3';
 import { action } from 'lib/convex';
 import { env } from 'schemas/envSchema';
 
-const dictionary = [
-	'Meseeks', //
-	'DeepSeek',
-	'Qwen',
-	'GPT',
-].join(',');
+const openAIBaseUrl = 'https://api.openai.com/v1';
+const realtimeModel = 'gpt-realtime-whisper';
+const fileModel = 'gpt-4o-transcribe';
+const maxTranscriptionBytes = 25 * 1024 * 1024;
+const maxSdpCharacters = 256 * 1024;
 
-const baseUrl = 'https://api.mistral.ai/v1';
-const model = 'voxtral-mini-latest';
+const defaultDictionary = ['Meseeks', 'DeepSeek', 'Qwen'];
 
 const audioArrayBufferSchema = z.unknown().transform((value, ctx) => {
 	//
@@ -35,36 +29,139 @@ const audioContentTypeSchema = z
 	.regex(/^audio\/[a-z0-9.+-]+(?:;.*)?$/i)
 	.optional();
 
-export const transcribe = action({
+const dictionarySchema = z.array(z.string().trim().min(1).max(80)).max(40).optional();
+
+const languageSchema = z
+	.string()
+	.trim()
+	.regex(/^[a-z]{2}(?:-[A-Z]{2})?$/)
+	.optional();
+
+const noiseReductionSchema = z.enum(['near_field', 'far_field']).optional();
+
+const vadSchema = z
+	.object({
+		threshold: z.number().min(0).max(1).optional(),
+		prefixPaddingMs: z.number().int().min(0).max(1000).optional(),
+		silenceDurationMs: z.number().int().min(200).max(3000).optional(),
+	})
+	.optional();
+
+export const createRealtimeTranscriptionCall = action({
 	args: {
-		audio: audioArrayBufferSchema,
-		contentType: audioContentTypeSchema,
+		sdp: z.string().min(1).max(maxSdpCharacters),
+		dictionary: dictionarySchema,
+		language: languageSchema,
+		noiseReduction: noiseReductionSchema,
+		includeLogprobs: z.boolean().optional(),
+		vad: vadSchema,
 	},
-	handler: async (ctx, { audio, contentType }) => {
+	handler: async (ctx, args) => {
 		//
 		const identity = await ctx.auth.getUserIdentity();
 		if (!identity) throw new Error('Unauthorized');
 
-		const audioBlob = new Blob([audio], { type: contentType ?? 'audio/webm' });
-		const file = new File([audioBlob], 'recording.webm', { type: audioBlob.type });
+		const prompt = buildPrompt(args.dictionary);
+		const formData = new FormData();
+		formData.set('sdp', args.sdp);
+		formData.set(
+			'session',
+			JSON.stringify(
+				buildRealtimeTranscriptionSession({
+					prompt,
+					language: args.language,
+					noiseReduction: args.noiseReduction,
+					includeLogprobs: args.includeLogprobs,
+					vad: args.vad,
+				}),
+			),
+		);
+
+		const response = await fetch(`${openAIBaseUrl}/realtime/calls`, {
+			method: 'POST',
+			headers: {
+				'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+				'OpenAI-Safety-Identifier': await safetyIdentifier(identity.subject),
+			},
+			body: formData,
+		});
+
+		const sdp = await response.text();
+
+		if (!response.ok) {
+			console.error('OpenAI realtime transcription setup failed:', {
+				status: response.status,
+				error: sdp,
+			});
+			throw new Error(`Realtime transcription setup failed: ${response.status}`);
+		}
+
+		if (!sdp.trim()) {
+			throw new Error('Realtime transcription setup returned an empty SDP answer');
+		}
+
+		console.debug('Realtime transcription session created', {
+			model: realtimeModel,
+			characterCount: sdp.length,
+			dictionary: prompt,
+		});
+
+		return {
+			sdp,
+			model: realtimeModel,
+		};
+	},
+});
+
+export const transcribe = action({
+	args: {
+		audio: audioArrayBufferSchema,
+		contentType: audioContentTypeSchema,
+		dictionary: dictionarySchema,
+		language: languageSchema,
+	},
+	handler: async (ctx, { audio, contentType, dictionary, language }) => {
+		//
+		const identity = await ctx.auth.getUserIdentity();
+		if (!identity) throw new Error('Unauthorized');
+
+		if (audio.byteLength > maxTranscriptionBytes) {
+			throw new Error('Audio is too large to transcribe');
+		}
+
+		const normalizedContentType = normalizeAudioContentType(contentType);
+		if (contentType && !normalizedContentType) {
+			throw new Error('Unsupported audio format');
+		}
+
+		const audioBlob = new Blob([audio], { type: normalizedContentType ?? 'audio/webm' });
+		const file = new File([audioBlob], `recording.${audioExtension(audioBlob.type)}`, {
+			type: audioBlob.type,
+		});
+		const prompt = buildPrompt(dictionary);
 
 		const formData = new FormData();
 		formData.append('file', file);
-		formData.append('model', model);
-		formData.append('context_bias', dictionary);
-		formData.append('temperature', '0');
+		formData.append('model', fileModel);
+		formData.append('prompt', prompt);
+		formData.append('response_format', 'json');
 
-		const response = await fetch(`${baseUrl}/audio/transcriptions`, {
+		if (language) {
+			formData.append('language', language);
+		}
+
+		const response = await fetch(`${openAIBaseUrl}/audio/transcriptions`, {
 			method: 'POST',
 			headers: {
-				Authorization: `Bearer ${env.MISTRAL_API_KEY}`,
+				'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+				'OpenAI-Safety-Identifier': await safetyIdentifier(identity.subject),
 			},
 			body: formData,
 		});
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			console.error('Mistral transcription failed:', { status: response.status, error: errorText });
+			console.error('OpenAI transcription failed:', { status: response.status, error: errorText });
 			throw new Error(`Transcription failed: ${response.status}`);
 		}
 
@@ -73,13 +170,123 @@ export const transcribe = action({
 		const transcription = result.text.trim();
 
 		console.debug('Transcription result', {
-			model,
-			baseUrl,
+			model: fileModel,
+			baseUrl: openAIBaseUrl,
 			characterCount: transcription.length,
-			contextBias: dictionary,
+			dictionary: prompt,
 			text: transcription,
 		});
 
 		return transcription;
 	},
 });
+
+function buildRealtimeTranscriptionSession({
+	prompt,
+	language,
+	noiseReduction,
+	includeLogprobs,
+	vad,
+}: {
+	prompt: string;
+	language?: string;
+	noiseReduction?: 'near_field' | 'far_field';
+	includeLogprobs?: boolean;
+	vad?: {
+		threshold?: number;
+		prefixPaddingMs?: number;
+		silenceDurationMs?: number;
+	};
+}) {
+	//
+	return {
+		type: 'transcription',
+		audio: {
+			input: {
+				noise_reduction: {
+					type: noiseReduction ?? 'near_field',
+				},
+				transcription: {
+					model: realtimeModel,
+					prompt,
+					...(language && { language }),
+				},
+				turn_detection: {
+					type: 'server_vad',
+					threshold: vad?.threshold ?? 0.5,
+					prefix_padding_ms: vad?.prefixPaddingMs ?? 300,
+					silence_duration_ms: vad?.silenceDurationMs ?? 500,
+				},
+			},
+		},
+		...(includeLogprobs && { include: ['item.input_audio_transcription.logprobs'] }),
+	};
+}
+
+function buildPrompt(dictionary: string[] | undefined) {
+	//
+	const terms = Array.from(new Set(defaultDictionary.concat(dictionary ?? []).map((term) => term.trim()))).filter(
+		Boolean,
+	);
+
+	return `Keywords: ${terms.join(', ')}`;
+}
+
+function normalizeAudioContentType(contentType: string | undefined) {
+	//
+	if (!contentType) return undefined;
+
+	const normalized = contentType.split(';')[0]?.trim().toLowerCase();
+	if (!normalized) return undefined;
+
+	if (supportedAudioTypes.has(normalized)) return normalized;
+	return undefined;
+}
+
+function audioExtension(contentType: string) {
+	//
+	const normalized = normalizeAudioContentType(contentType);
+
+	switch (normalized) {
+		case 'audio/flac':
+			return 'flac';
+		case 'audio/mp4':
+		case 'audio/m4a':
+			return 'm4a';
+		case 'audio/mpeg':
+		case 'audio/mp3':
+		case 'audio/mpga':
+			return 'mp3';
+		case 'audio/ogg':
+			return 'ogg';
+		case 'audio/wav':
+		case 'audio/x-wav':
+			return 'wav';
+		case 'audio/webm':
+		default:
+			return 'webm';
+	}
+}
+
+const supportedAudioTypes = new Set([
+	'audio/flac',
+	'audio/m4a',
+	'audio/mp3',
+	'audio/mp4',
+	'audio/mpeg',
+	'audio/mpga',
+	'audio/ogg',
+	'audio/wav',
+	'audio/webm',
+	'audio/x-wav',
+]);
+
+async function safetyIdentifier(subject: string) {
+	//
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(subject));
+	const hash = Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+
+	return `user_${hash}`;
+}

--- a/apps/meseeks/schemas/envSchema.ts
+++ b/apps/meseeks/schemas/envSchema.ts
@@ -122,7 +122,8 @@ export const env = createEnv({
 
 		GROQ_API_KEY: z.string().min(1).describe('Groq API key.'),
 		INCEPTION_API_KEY: z.string().min(1).describe('Inception Labs API key.'),
-		MISTRAL_API_KEY: z.string().min(1).describe('Mistral API key.'),
+		OPENAI_API_KEY: z.string().min(1).describe('OpenAI API key.'),
+		MISTRAL_API_KEY: z.string().min(1).optional().describe('Legacy Mistral API key.'),
 		MOONSHOT_API_KEY: z.string().min(1).describe('Moonshot API key.'),
 
 		NODE_ENV: z.enum(['development', 'production']).default('development').describe('Automatically populated.'),

--- a/apps/meseeks/src/components/ActionComposer/ActionComposer.tsx
+++ b/apps/meseeks/src/components/ActionComposer/ActionComposer.tsx
@@ -9,7 +9,6 @@ import { useVoiceRecording } from '~/hooks/useVoiceRecording';
 import { cn } from '@reactor/ui/lib/utils';
 import { IdleState } from './IdleState';
 import { RecordingState } from './RecordingState';
-import { TranscribingState } from './TranscribingState';
 import { StripContainer } from './strips/StripContainer';
 
 interface ActionComposerProps {
@@ -55,15 +54,14 @@ export function ActionComposer({ task, onSubmit, className }: ActionComposerProp
 		setMessage(e.target.value);
 	};
 
-	// sync local message back to URL when voice transcription completes
-	const handleTranscriptionComplete = (transcribedText: string) => {
+	const handleTranscriptionUpdate = (transcribedText: string) => {
 		//
 		setLocalMessage(transcribedText);
 		setMessage(transcribedText);
 	};
 
 	const { recordingStatus, startRecording, stopRecording, cancelRecording } = useVoiceRecording({
-		onTranscriptionComplete: handleTranscriptionComplete,
+		onTranscriptionUpdate: handleTranscriptionUpdate,
 	});
 
 	const isRecordingOrTranscribing = recordingStatus !== 'idle';
@@ -110,6 +108,11 @@ export function ActionComposer({ task, onSubmit, className }: ActionComposerProp
 	const handleStop = () => {
 		//
 		stop({ taskId: task._id });
+	};
+
+	const handleStartRecording = () => {
+		//
+		void startRecording(localMessage);
 	};
 
 	// global focus shortcut (⌘+I)
@@ -181,13 +184,15 @@ export function ActionComposer({ task, onSubmit, className }: ActionComposerProp
 					</div>
 				)}
 
-				{/* recording state */}
-				{recordingStatus === 'recording' && (
-					<RecordingState stopRecording={stopRecording} cancelRecording={cancelRecording} />
+				{/* live voice state */}
+				{recordingStatus !== 'idle' && (
+					<RecordingState
+						status={recordingStatus}
+						transcript={localMessage}
+						stopRecording={stopRecording}
+						cancelRecording={cancelRecording}
+					/>
 				)}
-
-				{/* transcribing state */}
-				{recordingStatus === 'transcribing' && <TranscribingState cancelRecording={cancelRecording} />}
 
 				{/* idle state - input and action bar */}
 				{!isRecordingOrTranscribing && (
@@ -198,7 +203,7 @@ export function ActionComposer({ task, onSubmit, className }: ActionComposerProp
 						handleMessageChange={handleMessageChange}
 						isEmpty={isLocalEmpty}
 						hasQueuedSkills={queue.length > 0}
-						startRecording={startRecording}
+						startRecording={handleStartRecording}
 						handleAct={handleAct}
 						handleEnqueue={handleEnqueueMessage}
 						isActing={isTaskActing}

--- a/apps/meseeks/src/components/ActionComposer/RecordingState.tsx
+++ b/apps/meseeks/src/components/ActionComposer/RecordingState.tsx
@@ -1,39 +1,62 @@
 import { Square, X } from 'lucide-react';
 import { ActionButton } from '@reactor/ui/action-button';
 import { TextShimmer } from '@reactor/ui/text-shimmer';
+import type { RecordingStatus } from '~/hooks/useVoiceRecording';
 
 export function RecordingState({
+	status = 'recording',
+	transcript,
 	stopRecording,
 	cancelRecording,
 }: {
+	status?: Exclude<RecordingStatus, 'idle'>;
+	transcript?: string;
 	stopRecording: () => void;
 	cancelRecording: () => void;
 }) {
 	//
+	const canStop = status === 'recording';
+	const statusText = getStatusText(status);
+	const preview = transcript?.trim();
+
 	return (
 		<>
-			<div className="flex flex-grow items-center justify-center px-2">
-				<TextShimmer text="Recording voice..." size="lg" />
+			<div className="flex min-w-0 flex-grow flex-col justify-center gap-2 px-2">
+				<TextShimmer text={statusText} size={preview ? 'sm' : 'lg'} />
+				{preview && (
+					<div className="text-primary max-h-36 overflow-y-auto whitespace-pre-wrap rounded-2xl border border-border/50 bg-background/40 px-3 py-2 text-sm leading-relaxed">
+						{preview}
+					</div>
+				)}
 			</div>
 
 			<div className="flex items-center justify-between gap-2 pt-2">
 				<div className="flex items-center gap-2">{/* Empty div to maintain layout consistency */}</div>
 
 				<div className="flex items-center gap-2">
-					<ActionButton
-						icon={<Square className="size-5" />}
-						onClick={stopRecording}
-						tooltip="Stop & transcribe"
-						variant="secondary"
-					/>
+					{canStop && (
+						<ActionButton
+							icon={<Square className="size-5" />}
+							onClick={stopRecording}
+							tooltip="Stop & transcribe"
+							variant="secondary"
+						/>
+					)}
 					<ActionButton
 						icon={<X className="size-5" />}
 						onClick={cancelRecording}
-						tooltip="Cancel recording"
+						tooltip="Cancel transcription"
 						variant="destructive"
 					/>
 				</div>
 			</div>
 		</>
 	);
+}
+
+function getStatusText(status: Exclude<RecordingStatus, 'idle'>) {
+	//
+	if (status === 'connecting') return 'Starting live transcription...';
+	if (status === 'transcribing') return 'Finishing transcript...';
+	return 'Listening live...';
 }

--- a/apps/meseeks/src/components/QuickSeek.tsx
+++ b/apps/meseeks/src/components/QuickSeek.tsx
@@ -7,7 +7,6 @@ import { INSUFFICIENT_ACCOUNT_FUNDS_ERROR, isError } from 'lib/errors';
 import { INTELLIGENCE_PROGRESSION, intelligenceKeys, type IntelligenceKey } from 'schemas/intelligenceSchema';
 import { ArrowUp, Mic } from 'lucide-react';
 import { RecordingState } from '~/components/ActionComposer/RecordingState';
-import { TranscribingState } from '~/components/ActionComposer/TranscribingState';
 import { BudgetSelector } from '~/components/BudgetSelector';
 import { IntelligenceSelector } from '~/components/IntelligenceSelector';
 import { Loading } from '~/components/Loading';
@@ -75,14 +74,14 @@ export function QuickSeekContent({ className }: { className?: string }) {
 	} = useExpandingTextarea({ initialValue: q || '' });
 
 	const { recordingStatus, startRecording, stopRecording, cancelRecording } = useVoiceRecording({
-		onTranscriptionComplete: setMessage,
+		onTranscriptionUpdate: setMessage,
 	});
 
 	const placeholder = useMemo(() => PLACEHOLDERS[0] ?? "What's happening?", []);
 
 	const handleStartRecording = async () => {
 		try {
-			await startRecording();
+			await startRecording(message);
 		} catch (error) {
 			console.error('Failed to start voice recording:', error);
 		}
@@ -166,11 +165,14 @@ export function QuickSeekContent({ className }: { className?: string }) {
 						showVoiceInterface && 'flex-row',
 					)}
 				>
-					{'recording' === recordingStatus && (
-						<RecordingState stopRecording={stopRecording} cancelRecording={cancelRecording} />
+					{'idle' !== recordingStatus && (
+						<RecordingState
+							status={recordingStatus}
+							transcript={message}
+							stopRecording={stopRecording}
+							cancelRecording={cancelRecording}
+						/>
 					)}
-
-					{'transcribing' === recordingStatus && <TranscribingState cancelRecording={cancelRecording} />}
 
 					{'idle' === recordingStatus && (
 						<>

--- a/apps/meseeks/src/hooks/useVoiceRecording.ts
+++ b/apps/meseeks/src/hooks/useVoiceRecording.ts
@@ -3,19 +3,61 @@ import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { api } from 'convex/_generated/api';
 
-type RecordingStatus = 'idle' | 'recording' | 'transcribing';
+export type RecordingStatus = 'idle' | 'connecting' | 'recording' | 'transcribing';
 
-interface UseVoiceRecordingProps {
-	onTranscriptionComplete: (text: string) => void;
-}
+type TranscriptionSegment = {
+	text: string;
+	final: boolean;
+};
 
-export function useVoiceRecording({ onTranscriptionComplete }: UseVoiceRecordingProps) {
+type RealtimeEvent = {
+	type?: string;
+	item_id?: string;
+	previous_item_id?: string;
+	delta?: string;
+	transcript?: string;
+	error?: {
+		message?: string;
+	};
+};
+
+type UseVoiceRecordingProps = {
+	onTranscriptionUpdate: (text: string) => void;
+	onTranscriptionComplete?: (text: string) => void;
+	language?: string;
+};
+
+const transcriptionSettleMs = 1200;
+const defaultLanguage = 'en';
+
+export function useVoiceRecording({
+	onTranscriptionUpdate,
+	onTranscriptionComplete,
+	language = defaultLanguage,
+}: UseVoiceRecordingProps) {
 	//
+	const createRealtimeCall = useAction(api.magicRock.createRealtimeTranscriptionCall);
 	const transcribeAction = useAction(api.magicRock.transcribe);
 
 	const streamRef = useRef<MediaStream | null>(null);
-	const currentStatusRef = useRef<RecordingStatus>('idle');
+	const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+	const dataChannelRef = useRef<RTCDataChannel | null>(null);
 	const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+	const mediaChunksRef = useRef<Blob[]>([]);
+	const currentStatusRef = useRef<RecordingStatus>('idle');
+	const modeRef = useRef<'realtime' | 'buffered' | null>(null);
+	const baseTextRef = useRef('');
+	const latestTextRef = useRef('');
+	const sessionIdRef = useRef(0);
+	const ignoreBufferedStopRef = useRef(false);
+	const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const itemOrderRef = useRef<string[]>([]);
+	const transcriptByItemIdRef = useRef<Map<string, TranscriptionSegment>>(new Map());
+	const onUpdateRef = useRef(onTranscriptionUpdate);
+	const onCompleteRef = useRef(onTranscriptionComplete);
+
+	onUpdateRef.current = onTranscriptionUpdate;
+	onCompleteRef.current = onTranscriptionComplete;
 
 	const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>('idle');
 
@@ -25,81 +67,354 @@ export function useVoiceRecording({ onTranscriptionComplete }: UseVoiceRecording
 		setRecordingStatus(status);
 	}, []);
 
-	const startRecording = useCallback(async () => {
+	const clearSettleTimer = useCallback(() => {
 		//
-		try {
+		if (!settleTimerRef.current) return;
+		clearTimeout(settleTimerRef.current);
+		settleTimerRef.current = null;
+	}, []);
+
+	const stopStream = useCallback(() => {
+		//
+		streamRef.current?.getTracks().forEach((track) => track.stop());
+		streamRef.current = null;
+	}, []);
+
+	const closeRealtime = useCallback(() => {
+		//
+		dataChannelRef.current?.close();
+		dataChannelRef.current = null;
+
+		peerConnectionRef.current?.getSenders().forEach((sender) => sender.track?.stop());
+		peerConnectionRef.current?.close();
+		peerConnectionRef.current = null;
+
+		stopStream();
+	}, [stopStream]);
+
+	const finishRealtime = useCallback(() => {
+		//
+		clearSettleTimer();
+		closeRealtime();
+		modeRef.current = null;
+		onCompleteRef.current?.(latestTextRef.current);
+		updateStatus('idle');
+	}, [clearSettleTimer, closeRealtime, updateStatus]);
+
+	const emitTranscript = useCallback(() => {
+		//
+		const transcript = itemOrderRef.current
+			.map((itemId) => transcriptByItemIdRef.current.get(itemId)?.text)
+			.filter((text): text is string => Boolean(text?.trim()))
+			.join(' ');
+
+		const nextText = appendTranscript(baseTextRef.current, normalizeTranscript(transcript));
+		latestTextRef.current = nextText;
+		onUpdateRef.current(nextText);
+	}, []);
+
+	const rememberItem = useCallback((itemId: string, previousItemId?: string) => {
+		//
+		if (itemOrderRef.current.includes(itemId)) return;
+
+		if (previousItemId) {
+			const previousIndex = itemOrderRef.current.indexOf(previousItemId);
+			if (previousIndex !== -1) {
+				itemOrderRef.current.splice(previousIndex + 1, 0, itemId);
+				return;
+			}
+		}
+
+		itemOrderRef.current.push(itemId);
+	}, []);
+
+	const handleRealtimeEvent = useCallback(
+		(event: RealtimeEvent) => {
+			//
+			if (event.type === 'input_audio_buffer.committed' && event.item_id) {
+				rememberItem(event.item_id, event.previous_item_id);
+				return;
+			}
+
+			if (event.type === 'conversation.item.input_audio_transcription.delta') {
+				if (!event.item_id || typeof event.delta !== 'string') return;
+
+				rememberItem(event.item_id);
+				const existing = transcriptByItemIdRef.current.get(event.item_id);
+				transcriptByItemIdRef.current.set(event.item_id, {
+					text: `${existing?.text ?? ''}${event.delta}`,
+					final: false,
+				});
+				emitTranscript();
+				return;
+			}
+
+			if (event.type === 'conversation.item.input_audio_transcription.completed') {
+				if (!event.item_id || typeof event.transcript !== 'string') return;
+
+				rememberItem(event.item_id);
+				transcriptByItemIdRef.current.set(event.item_id, {
+					text: event.transcript,
+					final: true,
+				});
+				emitTranscript();
+				return;
+			}
+
+			if (event.type === 'conversation.item.input_audio_transcription.failed') {
+				toast.error('Realtime transcription failed.', {
+					description: event.error?.message,
+				});
+				return;
+			}
+
+			if (event.type === 'error') {
+				toast.error('Realtime transcription error.', {
+					description: event.error?.message,
+				});
+			}
+		},
+		[emitTranscript, rememberItem],
+	);
+
+	const handleDataChannelMessage = useCallback(
+		(event: MessageEvent<string>) => {
+			//
+			try {
+				handleRealtimeEvent(JSON.parse(event.data) as RealtimeEvent);
+			} catch (error) {
+				console.error('Failed to parse realtime transcription event:', error);
+			}
+		},
+		[handleRealtimeEvent],
+	);
+
+	const resetTranscript = useCallback((baseText: string) => {
+		//
+		baseTextRef.current = baseText;
+		latestTextRef.current = baseText;
+		itemOrderRef.current = [];
+		transcriptByItemIdRef.current = new Map();
+	}, []);
+
+	const startRealtimeRecording = useCallback(
+		async (sessionId: number, baseText: string) => {
+			//
+			modeRef.current = 'realtime';
+
+			const stream = await navigator.mediaDevices.getUserMedia({
+				audio: {
+					echoCancellation: true,
+					noiseSuppression: true,
+					autoGainControl: true,
+				},
+			});
+
+			if (sessionIdRef.current !== sessionId) {
+				stream.getTracks().forEach((track) => track.stop());
+				return;
+			}
+
+			streamRef.current = stream;
+
+			const peerConnection = new RTCPeerConnection();
+			peerConnectionRef.current = peerConnection;
+
+			stream.getAudioTracks().forEach((track) => peerConnection.addTrack(track, stream));
+
+			const dataChannel = peerConnection.createDataChannel('oai-events');
+			dataChannelRef.current = dataChannel;
+
+			dataChannel.addEventListener('open', () => {
+				if (sessionIdRef.current === sessionId && currentStatusRef.current === 'connecting') {
+					updateStatus('recording');
+				}
+			});
+			dataChannel.addEventListener('message', handleDataChannelMessage);
+			dataChannel.addEventListener('error', () => {
+				toast.error('Realtime transcription channel failed.');
+			});
+
+			peerConnection.addEventListener('connectionstatechange', () => {
+				if (peerConnection.connectionState === 'failed') {
+					toast.error('Realtime transcription connection failed.');
+					sessionIdRef.current += 1;
+					closeRealtime();
+					modeRef.current = null;
+					updateStatus('idle');
+				}
+			});
+
+			const offer = await peerConnection.createOffer();
+			await peerConnection.setLocalDescription(offer);
+
+			if (!offer.sdp) {
+				throw new Error('Realtime transcription did not create an SDP offer');
+			}
+
+			const { sdp } = await createRealtimeCall({
+				sdp: offer.sdp,
+				dictionary: extractDictionary(baseText),
+				language,
+				noiseReduction: 'near_field',
+				vad: {
+					threshold: 0.5,
+					prefixPaddingMs: 300,
+					silenceDurationMs: 500,
+				},
+			});
+
+			if (sessionIdRef.current !== sessionId) {
+				closeRealtime();
+				return;
+			}
+
+			await peerConnection.setRemoteDescription({
+				type: 'answer',
+				sdp,
+			});
+
+			if (currentStatusRef.current === 'connecting') {
+				updateStatus('recording');
+			}
+		},
+		[closeRealtime, createRealtimeCall, handleDataChannelMessage, language, updateStatus],
+	);
+
+	const startBufferedRecording = useCallback(
+		async (baseText: string) => {
+			//
+			if (!window.MediaRecorder) {
+				throw new Error('This browser does not support voice recording');
+			}
+
+			modeRef.current = 'buffered';
+			ignoreBufferedStopRef.current = false;
+			mediaChunksRef.current = [];
+
 			const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
 			streamRef.current = stream;
 
 			const mediaRecorder = new MediaRecorder(stream);
 			mediaRecorderRef.current = mediaRecorder;
 
-			const chunks: Blob[] = [];
-
 			mediaRecorder.ondataavailable = (event) => {
 				if (event.data.size > 0) {
-					chunks.push(event.data);
+					mediaChunksRef.current.push(event.data);
 				}
 			};
 
 			mediaRecorder.onstop = async () => {
 				//
-				const audio = new Blob(chunks, { type: mediaRecorder.mimeType });
+				stopStream();
 
-				if (currentStatusRef.current === 'recording') {
-					//
-					updateStatus('transcribing');
+				if (ignoreBufferedStopRef.current) {
+					return;
+				}
 
-					try {
-						const audioBuffer = await audio.arrayBuffer();
-						const transcriptionArgs = audio.type
-							? { audio: audioBuffer, contentType: audio.type }
-							: { audio: audioBuffer };
-						const text = await transcribeAction(transcriptionArgs);
-						onTranscriptionComplete(text);
-					} catch (error) {
-						console.error('Error transcribing audio:', error);
-						toast.error('Failed to transcribe audio. Please try again.');
-					} finally {
-						updateStatus('idle');
-					}
+				updateStatus('transcribing');
+
+				try {
+					const audio = new Blob(mediaChunksRef.current, { type: mediaRecorder.mimeType });
+					const audioBuffer = await audio.arrayBuffer();
+					const text = await transcribeAction({
+						audio: audioBuffer,
+						contentType: audio.type || undefined,
+						dictionary: extractDictionary(baseText),
+						language,
+					});
+					const nextText = appendTranscript(baseText, text);
+
+					latestTextRef.current = nextText;
+					onUpdateRef.current(nextText);
+					onCompleteRef.current?.(nextText);
+				} catch (error) {
+					console.error('Error transcribing audio:', error);
+					toast.error('Failed to transcribe audio. Please try again.');
+				} finally {
+					modeRef.current = null;
+					updateStatus('idle');
 				}
 			};
 
 			mediaRecorder.start();
 			updateStatus('recording');
+		},
+		[language, stopStream, transcribeAction, updateStatus],
+	);
+
+	const startRecording = useCallback(
+		async (baseText = '') => {
 			//
-		} catch (error) {
-			console.error('Error starting recording:', error);
-			toast.error('Unable to access microphone. Please check your browser permissions.');
-		}
-		//
-	}, [transcribeAction, onTranscriptionComplete, updateStatus]);
+			if (currentStatusRef.current !== 'idle') return;
+
+			const sessionId = sessionIdRef.current + 1;
+			sessionIdRef.current = sessionId;
+			clearSettleTimer();
+			resetTranscript(baseText);
+			updateStatus('connecting');
+
+			try {
+				if (supportsRealtimeRecording()) {
+					await startRealtimeRecording(sessionId, baseText);
+				} else {
+					await startBufferedRecording(baseText);
+				}
+			} catch (error) {
+				console.error('Error starting voice recording:', error);
+				closeRealtime();
+				stopStream();
+				modeRef.current = null;
+				updateStatus('idle');
+				toast.error('Unable to start voice transcription. Please check your microphone permissions.');
+			}
+		},
+		[
+			clearSettleTimer,
+			closeRealtime,
+			resetTranscript,
+			startBufferedRecording,
+			startRealtimeRecording,
+			stopStream,
+			updateStatus,
+		],
+	);
 
 	const stopRecording = useCallback(() => {
 		//
-		if (mediaRecorderRef.current && currentStatusRef.current === 'recording') {
-			mediaRecorderRef.current.stop();
+		if (currentStatusRef.current !== 'recording' && currentStatusRef.current !== 'connecting') return;
+
+		if (modeRef.current === 'buffered') {
+			if (mediaRecorderRef.current?.state === 'recording') {
+				mediaRecorderRef.current.stop();
+			}
+			stopStream();
+			return;
 		}
 
-		if (streamRef.current) {
-			streamRef.current.getTracks().forEach((track) => track.stop());
-			streamRef.current = null;
-		}
-	}, []);
+		updateStatus('transcribing');
+		stopStream();
+		clearSettleTimer();
+		settleTimerRef.current = setTimeout(finishRealtime, transcriptionSettleMs);
+	}, [clearSettleTimer, finishRealtime, stopStream, updateStatus]);
 
 	const cancelRecording = useCallback(() => {
-		updateStatus('idle');
+		//
+		sessionIdRef.current += 1;
+		ignoreBufferedStopRef.current = true;
+		clearSettleTimer();
 
-		if (mediaRecorderRef.current) {
+		if (mediaRecorderRef.current?.state === 'recording') {
 			mediaRecorderRef.current.stop();
 		}
 
-		if (streamRef.current) {
-			streamRef.current.getTracks().forEach((track) => track.stop());
-			streamRef.current = null;
-		}
-	}, [updateStatus]);
+		closeRealtime();
+		stopStream();
+		modeRef.current = null;
+		latestTextRef.current = baseTextRef.current;
+		onUpdateRef.current(baseTextRef.current);
+		updateStatus('idle');
+	}, [clearSettleTimer, closeRealtime, stopStream, updateStatus]);
 
 	return {
 		recordingStatus,
@@ -107,4 +422,36 @@ export function useVoiceRecording({ onTranscriptionComplete }: UseVoiceRecording
 		stopRecording,
 		cancelRecording,
 	};
+}
+
+function supportsRealtimeRecording() {
+	//
+	return typeof window !== 'undefined' && 'RTCPeerConnection' in window && navigator.mediaDevices;
+}
+
+function appendTranscript(baseText: string, transcript: string) {
+	//
+	const nextTranscript = transcript.trim();
+	if (!nextTranscript) return baseText;
+
+	const trimmedBase = baseText.trimEnd();
+	if (!trimmedBase) return nextTranscript;
+
+	return `${trimmedBase}\n\n${nextTranscript}`;
+}
+
+function normalizeTranscript(transcript: string) {
+	//
+	return transcript
+		.replace(/\s+([,.!?;:])/g, '$1')
+		.replace(/\s{2,}/g, ' ')
+		.trim();
+}
+
+function extractDictionary(text: string) {
+	//
+	const terms = text.match(/[A-Za-z][A-Za-z0-9_.$:/-]{2,}/g) ?? [];
+	const highSignalTerms = terms.filter((term) => /[A-Z0-9_.$:/-]/.test(term) || term.length > 12);
+
+	return Array.from(new Set(highSignalTerms)).slice(0, 32);
 }


### PR DESCRIPTION
## Summary

- Replace the Composer voice path with an OpenAI Realtime WebRTC transcription setup using `gpt-realtime-whisper`.
- Keep an OpenAI Audio API fallback with `gpt-4o-transcribe` for browsers without WebRTC support.
- Stream partial transcript text into ActionComposer and QuickSeek, append repeated dictation to the current prompt, and allow cancel-to-revert.
- Add `OPENAI_API_KEY` to the app env schema and keep `MISTRAL_API_KEY` as legacy optional config.

## Validation

- `git diff --check`
- `bun --cwd apps/meseeks lint`
- `bun --cwd apps/meseeks typecheck` currently fails on pre-existing project type issues: missing `@babel/core` declarations and Bun test type declarations.