### PR TITLE
[codex] Use Vercel URL for preview auth

### DIFF
--- a/apps/meseeks/convex/betterAuth/runtime.private.ts
+++ b/apps/meseeks/convex/betterAuth/runtime.private.ts
@@ -10,7 +10,7 @@ export function createBetterAuth(ctx: GenericCtx<DataModel>) {
 	//
 	return betterAuth(
 		createAuthOptions({
-			baseURL: `${env.SITE_URL}${authBasePath}`,
+			baseURL: `${getAuthSiteUrl()}${authBasePath}`,
 			siteUrl: env.SITE_URL,
 			secret: env.BETTER_AUTH_SECRET,
 			googleClientId: env.AUTH_GOOGLE_ID,
@@ -20,4 +20,10 @@ export function createBetterAuth(ctx: GenericCtx<DataModel>) {
 			database: betterAuthComponent.adapter(ctx),
 		}),
 	);
+}
+
+function getAuthSiteUrl() {
+	//
+	if (env.VERCEL_URL) return `https://${env.VERCEL_URL}`;
+	return env.SITE_URL;
 }

--- a/apps/meseeks/schemas/envSchema.ts
+++ b/apps/meseeks/schemas/envSchema.ts
@@ -8,6 +8,7 @@ export const env = createEnv({
 	server: {
 		//
 		SITE_URL: z.string().min(1).describe('The app public URL.'),
+		VERCEL_URL: z.string().min(1).optional().describe('Vercel deployment URL without the protocol.'),
 		BETTER_AUTH_SECRET: z.string().min(1).describe('Better Auth application secret.'),
 
 		POLAR_SERVER: z.enum(['sandbox', 'production']).default('sandbox').describe('Polar server.'),


### PR DESCRIPTION
## Summary

- Use Vercel's deployment URL for the Better Auth base URL when `VERCEL_URL` is present.
- Keep `SITE_URL` as the fallback for non-Vercel/local environments.
- Add `VERCEL_URL` to the server env schema as an optional Vercel-provided value.

## Why

Preview deployments get generated Vercel domains, so using a static `SITE_URL` makes Better Auth build callbacks for the wrong host. This keeps the change narrow and avoids trusting arbitrary proxy headers.

## Validation

- `bunx oxlint apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/schemas/envSchema.ts`
- `bunx oxfmt --check apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/schemas/envSchema.ts`
- `git diff --check`

Full `bun run typecheck` still fails on existing workspace issues: missing `@babel/core` declarations and Bun test types.