### PR TITLE
[codex] Trust Vercel auth origin

### DIFF
--- a/apps/meseeks/convex/betterAuth/runtime.private.ts
+++ b/apps/meseeks/convex/betterAuth/runtime.private.ts
@@ -8,10 +8,12 @@ import { betterAuthComponent } from './component';
 
 export function createBetterAuth(ctx: GenericCtx<DataModel>) {
 	//
+	const authSiteUrl = getAuthSiteUrl();
+
 	return betterAuth(
 		createAuthOptions({
-			baseURL: `${getAuthSiteUrl()}${authBasePath}`,
-			siteUrl: env.SITE_URL,
+			baseURL: `${authSiteUrl}${authBasePath}`,
+			siteUrl: authSiteUrl,
 			secret: env.BETTER_AUTH_SECRET,
 			googleClientId: env.AUTH_GOOGLE_ID,
 			googleClientSecret: env.AUTH_GOOGLE_SECRET,


### PR DESCRIPTION
## Summary
- Use the Vercel-derived auth site URL for Better Auth `siteUrl`, not only `baseURL`.
- Keep `baseURL` and `siteUrl` aligned for preview deployments.

## Why
`/api/auth/sign-in/social` was still returning `INVALID_ORIGIN` because this repo builds Better Auth `trustedOrigins` from `siteUrl`. The previous PR changed `baseURL`, but `siteUrl` still came from `SITE_URL`, so preview callback URLs were rejected before Google OAuth.

## Validation
- `bunx oxlint apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/schemas/envSchema.ts`
- `bunx oxfmt --check apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/schemas/envSchema.ts`