### PR TITLE
[codex] Enable preview anonymous sign-in

### DIFF
--- a/apps/meseeks/convex/betterAuth/runtime.private.ts
+++ b/apps/meseeks/convex/betterAuth/runtime.private.ts
@@ -8,15 +8,14 @@ import { betterAuthComponent } from './component';
 
 export function createBetterAuth(ctx: GenericCtx<DataModel>) {
 	//
-	const authSiteUrl = getAuthSiteUrl();
-
 	return betterAuth(
 		createAuthOptions({
-			baseURL: `${authSiteUrl}${authBasePath}`,
-			siteUrl: authSiteUrl,
+			baseURL: `${env.SITE_URL}${authBasePath}`,
+			siteUrl: env.SITE_URL,
 			secret: env.BETTER_AUTH_SECRET,
 			googleClientId: env.AUTH_GOOGLE_ID,
 			googleClientSecret: env.AUTH_GOOGLE_SECRET,
+			allowAnonymousSignIn: shouldAllowAnonymousSignIn(),
 			sessionDurationSeconds: Math.floor(env.JWT_SESSION_DURATION_MS / 1000),
 			sessionUpdateAgeSeconds: Math.floor(env.JWT_SESSION_UPDATE_AGE_MS / 1000),
 			database: betterAuthComponent.adapter(ctx),
@@ -24,8 +23,7 @@ export function createBetterAuth(ctx: GenericCtx<DataModel>) {
 	);
 }
 
-function getAuthSiteUrl() {
+function shouldAllowAnonymousSignIn() {
 	//
-	if (env.VERCEL_URL) return `https://${env.VERCEL_URL}`;
-	return env.SITE_URL;
+	return env.ENV_TYPE !== 'production';
 }

--- a/apps/meseeks/lib/auth-client.ts
+++ b/apps/meseeks/lib/auth-client.ts
@@ -1,10 +1,11 @@
 import { convexClient } from '@convex-dev/better-auth/client/plugins';
+import { anonymousClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 import { authBasePath } from 'lib/auth';
 
 const authClient = createAuthClient({
 	basePath: authBasePath,
-	plugins: [convexClient()],
+	plugins: [convexClient(), anonymousClient()],
 });
 
 export const signIn = authClient.signIn;

--- a/apps/meseeks/lib/authOptions.ts
+++ b/apps/meseeks/lib/authOptions.ts
@@ -1,4 +1,5 @@
 import { convex as convexPlugin } from '@convex-dev/better-auth/plugins';
+import { anonymous } from 'better-auth/plugins';
 import type { AdapterFactory } from 'better-auth/adapters';
 import { authBasePath } from 'lib/auth';
 import authConfig from 'convex/auth.config';
@@ -9,6 +10,7 @@ type CreateAuthOptionsArgs = {
 	secret: string;
 	googleClientId: string;
 	googleClientSecret: string;
+	allowAnonymousSignIn: boolean;
 	sessionDurationSeconds: number;
 	sessionUpdateAgeSeconds: number;
 	database?: AdapterFactory;
@@ -32,6 +34,7 @@ export function createAuthOptions(input: CreateAuthOptionsArgs) {
 			encryptOAuthTokens: true,
 		},
 		advanced: {
+			disableOriginCheck: input.allowAnonymousSignIn,
 			cookies: {
 				convex_jwt: {
 					attributes: {
@@ -49,6 +52,7 @@ export function createAuthOptions(input: CreateAuthOptionsArgs) {
 			},
 		},
 		plugins: [
+			...(input.allowAnonymousSignIn ? [anonymous()] : []),
 			convexPlugin({
 				authConfig,
 				options: {
@@ -73,6 +77,7 @@ export function createCodegenAuthOptions() {
 		secret: 'component-auth-secret',
 		googleClientId: 'component-google-client-id',
 		googleClientSecret: 'component-google-client-secret',
+		allowAnonymousSignIn: true,
 		sessionDurationSeconds: 60 * 60 * 24 * 30, // 30 days
 		sessionUpdateAgeSeconds: 60 * 60 * 24, // 1 day
 	});

--- a/apps/meseeks/schemas/envSchema.ts
+++ b/apps/meseeks/schemas/envSchema.ts
@@ -8,7 +8,7 @@ export const env = createEnv({
 	server: {
 		//
 		SITE_URL: z.string().min(1).describe('The app public URL.'),
-		VERCEL_URL: z.string().min(1).optional().describe('Vercel deployment URL without the protocol.'),
+		ENV_TYPE: z.enum(['production', 'preview', 'development']).optional().describe('Deployment environment.'),
 		BETTER_AUTH_SECRET: z.string().min(1).describe('Better Auth application secret.'),
 
 		POLAR_SERVER: z.enum(['sandbox', 'production']).default('sandbox').describe('Polar server.'),

--- a/apps/meseeks/src/components/AccessDenied.tsx
+++ b/apps/meseeks/src/components/AccessDenied.tsx
@@ -8,11 +8,14 @@ const authErrorSearchSchema = z.object({
 	error: z.string().optional(),
 });
 
+const allowAnonymousSignIn = import.meta.env.VERCEL_ENV !== 'production';
+
 export function AccessDenied() {
 	//
 	const router = useRouter();
 	const { pathname, hash, search } = useLocation();
 	const [isSigningIn, setIsSigningIn] = useState(false);
+	const [isSigningInAnonymously, setIsSigningInAnonymously] = useState(false);
 	const authError = authErrorSearchSchema.parse(search).error;
 
 	const callbackUrl = useMemo(() => {
@@ -55,6 +58,20 @@ export function AccessDenied() {
 			});
 	};
 
+	const handleAnonymousSignIn = async () => {
+		//
+		setIsSigningInAnonymously(true);
+
+		await signIn
+			.anonymous()
+			.then(() => {
+				window.location.assign(callbackUrl);
+			})
+			.catch(() => {
+				setIsSigningInAnonymously(false);
+			});
+	};
+
 	return (
 		<div className="h-screen w-full flex flex-col items-center justify-center gap-4">
 			<div className="flex flex-wrap items-center justify-center gap-3">
@@ -63,6 +80,18 @@ export function AccessDenied() {
 				</LoadingButton>
 				{errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
 			</div>
+			{allowAnonymousSignIn && (
+				<div>
+					<LoadingButton
+						variant="secondary"
+						onClick={handleAnonymousSignIn}
+						loading={isSigningInAnonymously}
+						loadingText="Signing in..."
+					>
+						Continue anonymously
+					</LoadingButton>
+				</div>
+			)}
 			<footer className="absolute bottom-4 text-sm text-muted-foreground flex gap-4">
 				<a
 					href="/static/privacy-policy.md"


### PR DESCRIPTION
## Summary
- Remove the preview cross-domain auth and Vercel bypass-secret changes.
- Keep Convex Better Auth on `SITE_URL`.
- Enable Better Auth anonymous sign-in only when `ENV_TYPE` is not `production`.
- Disable Better Auth origin validation only when anonymous sign-in is enabled.
- Add a non-production anonymous sign-in button under the Google button on `AccessDenied`.
  The browser-facing gate uses Vercel's `VERCEL_ENV`.

## Validation
- `bunx oxlint apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/lib/auth-client.ts apps/meseeks/lib/authOptions.ts apps/meseeks/schemas/envSchema.ts apps/meseeks/src/components/AccessDenied.tsx apps/meseeks/src/components/ConvexAuthProvider.tsx apps/meseeks/vite.config.ts`
- `bunx oxfmt --check apps/meseeks/convex/betterAuth/runtime.private.ts apps/meseeks/lib/auth-client.ts apps/meseeks/lib/authOptions.ts apps/meseeks/schemas/envSchema.ts apps/meseeks/src/components/AccessDenied.tsx apps/meseeks/src/components/ConvexAuthProvider.tsx apps/meseeks/vite.config.ts`
- `bun run typecheck` still fails on existing repo issues: missing `@babel/core` declaration and Bun test type declarations.
