### PR TITLE
[codex] Require Convex environment type

### DIFF
--- a/apps/meseeks/schemas/envSchema.ts
+++ b/apps/meseeks/schemas/envSchema.ts
@@ -8,7 +8,7 @@ export const env = createEnv({
 	server: {
 		//
 		SITE_URL: z.string().min(1).describe('The app public URL.'),
-		ENV_TYPE: z.enum(['production', 'preview', 'development']).optional().describe('Deployment environment.'),
+		ENV_TYPE: z.enum(['production', 'preview', 'development']).describe('Deployment environment.'),
 		BETTER_AUTH_SECRET: z.string().min(1).describe('Better Auth application secret.'),
 
 		POLAR_SERVER: z.enum(['sandbox', 'production']).default('sandbox').describe('Polar server.'),


### PR DESCRIPTION
## Summary
- require Convex ENV_TYPE instead of treating a missing value as non-production
- force Vercel Preview deploys through Convex preview deployment creation
- make a bad Preview CONVEX_DEPLOY_KEY fail instead of deploying to a fixed dev deployment
- hide the anonymous sign-in button unless VERCEL_ENV is explicitly preview or development

## Convex preview setup
- Replace the Vercel Preview CONVEX_DEPLOY_KEY with a Convex Preview Deploy Key from Convex Project Settings.
- The key must be the preview-project key shape, not a dev/deployment key. With this PR, the wrong key will fail because preview deploys pass --preview-create.
- The existing build command still runs bun run deploy -> convex deploy --cmd 'bun run build'. Convex sets VITE_CONVEX_URL and VITE_CONVEX_SITE_URL for that build.
- In Convex Project Settings, set preview project environment variable defaults for every required schema env, especially ENV_TYPE=preview.
- Production Convex must have ENV_TYPE=production before this merges.

## Verification
- bun run lint
- bun run typecheck (fails on existing baseline: missing @babel/core declarations and bun:test/Bun types)