### PR TITLE
[codex] Guard Convex preview deploys

### DIFF
--- a/apps/meseeks/package.json
+++ b/apps/meseeks/package.json
@@ -12,7 +12,7 @@
 		"dev:db": "convex dev",
 		"dev:web": "vite dev --port 3000",
 		"build": "vite build",
-		"deploy": "convex deploy --cmd 'bun run build'",
+		"deploy": "if [ \"$VERCEL_ENV\" = \"preview\" ]; then convex deploy --preview-create \"$VERCEL_GIT_COMMIT_REF\" --cmd 'bun run build'; else convex deploy --cmd 'bun run build'; fi",
 		"start": "bun .output/server/index.mjs",
 		"typecheck": "tsgo --noEmit --incremental --tsBuildInfoFile .output/typecheck.tsbuildinfo",
 		"test": "bun test",

--- a/apps/meseeks/src/components/AccessDenied.tsx
+++ b/apps/meseeks/src/components/AccessDenied.tsx
@@ -8,7 +8,7 @@ const authErrorSearchSchema = z.object({
 	error: z.string().optional(),
 });
 
-const allowAnonymousSignIn = import.meta.env.VERCEL_ENV !== 'production';
+const allowAnonymousSignIn = import.meta.env.VERCEL_ENV === 'preview' || import.meta.env.VERCEL_ENV === 'development';
 
 export function AccessDenied() {
 	//

--- a/apps/meseeks/vite.config.ts
+++ b/apps/meseeks/vite.config.ts
@@ -7,6 +7,9 @@ import { defineConfig } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+	define: {
+		'import.meta.env.VERCEL_ENV': JSON.stringify(process.env['VERCEL_ENV'] ?? ''),
+	},
 	server: {
 		strictPort: false,
 	},


### PR DESCRIPTION
## Summary
- force Vercel Preview builds through Convex preview deployment creation
- make a wrong Preview CONVEX_DEPLOY_KEY fail instead of deploying to a fixed dev deployment
- hide the anonymous sign-in button unless VERCEL_ENV is explicitly preview or development
- expose only VERCEL_ENV to the Vite browser bundle so the preview-only UI can render

## Required external setup
- Replace Vercel Preview CONVEX_DEPLOY_KEY with a Convex Preview Deploy Key from https://dashboard.convex.dev/dp/notable-penguin-391/settings#preview-deploy-keys.
- The current Preview deploy is expected to fail with: Preview deployments can only be created with preview deploy keys.
- Keep Convex preview project defaults configured, especially ENV_TYPE=preview.

## Verification
- bunx oxfmt --check vite.config.ts src/components/AccessDenied.tsx package.json
- bunx oxlint vite.config.ts src/components/AccessDenied.tsx
- Vercel preview build fails before deploying because the current CONVEX_DEPLOY_KEY is not a preview deploy key