### PR TITLE
Lazy-load code highlighting task

### DIFF
--- a/tasks/backlog/lazy-load-code-highlighting.mdx
+++ b/tasks/backlog/lazy-load-code-highlighting.mdx
@@ -1,0 +1,32 @@
+---
+title: Lazy-load code highlighting
+priority: medium
+tags: [debt]
+---
+
+# Lazy-load code highlighting
+
+## Context
+Production builds emit many Shiki language chunks such as `objective-cpp`, `wolfram`, `wasm`, `cpp`, and `emacs-lisp` because `packages/ui/src/code-block.tsx` statically imports `codeToHtml` from `shiki`. The shared code block is used by MDX rendering and Analyze action panels, so Shiki is reachable from the client bundle even when code blocks are not central to the current page.
+
+The product still needs broad language support. Narrow Shiki bundles, `shiki/bundle/web`, server-side highlighting, and removing syntax highlighting are not acceptable directions for this task.
+
+## Objective
+Reduce first-load client bundle pressure from syntax highlighting while preserving full Shiki language support for rendered code blocks.
+
+## Subtasks
+- [ ] Replace the static `shiki` import in `packages/ui/src/code-block.tsx` with a lazy-loaded highlighter path.
+- [ ] Keep initial render as styled plain `<pre><code>` so MDX/code panels stay usable before highlighting resolves.
+- [ ] Load highlighting only when a multiline code block is rendered or an Analyze code panel is expanded.
+- [ ] Consider moving Shiki work into a Web Worker if main-thread highlighting causes visible UI stalls.
+- [ ] Verify `main-*.js` no longer absorbs Shiki runtime code, while full-language async assets may still exist in `dist`.
+
+## Progress Log
+### 2026-05-09
+- Task created from build-log investigation.
+
+## Notes
+- Source paths: `packages/ui/src/code-block.tsx`, `apps/meseeks/src/components/ui/mdx.tsx`, and `apps/meseeks/src/components/actions/AnalyzeAction.tsx`.
+- Do not use `manualChunks` as the primary fix; it can rearrange chunks but does not remove the eager client dependency.
+- User steer to preserve: needs all languages, does not want server-side highlighting, does not want to remove highlighting.
+- Learn hints: the key assumption to avoid is treating strange chunk names as icons or unused app code; they are Shiki grammar/runtime assets caused by a static client import.


### PR DESCRIPTION
## Summary
- Add a backlog task for lazy-loading client-side Shiki highlighting.
- Capture the root cause of the unexpected language chunks in production builds.
- Preserve the decided constraints: keep full language support, avoid server-side highlighting, and keep syntax highlighting.

## Validation
- `bun run tasks:build`