### PR TITLE
Upgrade smithers-orchestrator to smthrs

### DIFF
--- a/files/references/smithers-durable-jsx-ai-workflow/_index.md
+++ b/files/references/smithers-durable-jsx-ai-workflow/_index.md
@@ -11,8 +11,8 @@ https://smithers.sh
 interesting reference for JSX/react usage with AI.
 
 ```tsx
-/** @jsxImportSource smithers-orchestrator */
-import { createSmithers, Sequence, Task } from "smithers-orchestrator";
+/** @jsxImportSource smthrs */
+import { createSmithers, Sequence, Task } from "smthrs";
 import { z } from "zod";
 
 const { Workflow, smithers, outputs } = createSmithers({


### PR DESCRIPTION
The `smithers-orchestrator` package was renamed on npm to **`smthrs`** (no compatibility alias is published), current version 0.33.0.

This repo doesn't pin the package in `package.json`/lockfile — the only references were in the reference doc `files/references/smithers-durable-jsx-ai-workflow/_index.md`. This PR updates that code snippet:

- `/** @jsxImportSource smithers-orchestrator */` → `/** @jsxImportSource smthrs */`
- `import { ... } from "smithers-orchestrator"` → `from "smthrs"`

`git grep smithers-orchestrator` is clean after the change. Reviewed against the Smithers changelog: smthrs 0.33.0 is published and exports the required JSX runtime; no lockfile changes, unrelated changes, or whitespace errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)